### PR TITLE
Migrate to Spectre.Console.Cli

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using cman.Commands;
 using Spectre.Console.Cli;
-using Spectre.Cli.Extensions.DependencyInjection;
+using Spectre.Console.Cli.Extensions.DependencyInjection;
 
 IServiceCollection? serviceCollection = new ServiceCollection()
     .AddLogging(configure =>

--- a/cman.csproj
+++ b/cman.csproj
@@ -10,8 +10,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Spectre.Cli.Extensions.DependencyInjection" Version="0.4.0" />
-    <PackageReference Include="Spectre.Console" Version="0.44.0" />
+    <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.1.0" />
+    <PackageReference Include="Spectre.Console" Version="0.45.0" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Spectre.Console has removed CLI functions into its own Spectre.Console.Cli NuGet package, this PR addresses the changes needed to be able to adopt the latest Spectre.Console version.

* Update Spectre.Console to 0.45.0
* Add Spectre.Console.Cli 0.45.0
* Migrate from Spectre.Cli.Extensions.DependencyInjection to Spectre.Console.Cli.Extensions.DependencyInjection